### PR TITLE
lgtm.yml: remove GCC 8 requirement

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -16,8 +16,6 @@ extraction:
             - "export PATH=$PATH:~/.local/bin"
             - "conan --version"
             - "conan profile new default --detect"
-            - "conan profile update settings.compiler.version=8 default"
-            - "conan profile update settings.compiler.libcxx=libstdc++11 default"
             - "conan remote add -i 0 abbyssoul https://api.bintray.com/conan/abbyssoul/public-conan False"
 
         configure:


### PR DESCRIPTION
This will let the project continue to work when the lgtm.com build environment is upgraded to Ubuntu 19.10, where the default compiler is  GCC 9. I've also removed the libstdc++ ABI override for the sake of  future-proofing.

I've tested that the build still works at https://lgtm.com/logs/80f7b815aee60db67d9d65c6d71cf606384ecf12/lang:cpp.